### PR TITLE
Support reduced frame size in validation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.1'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,16 @@ UnitAliases = "96ae54c0-0dff-11e9-11b2-27e67f6cc5ea"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+AxisArrays = "0.4"
+DSP = "0.6"
+DataStructures = "0.17, 0.18"
+ImagineFormat = "1"
+ImagineHardware = "0.0.1"
+IntervalSets = "0.5"
+JSON = "0.21"
+MappedArrays = "0.2, 0.3"
+UnitAliases = "0.0.1"
+Unitful = "1"
 julia = "0.7, 1"
 
 [extras]

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -163,7 +163,7 @@ function center(input::ClosedInterval{Int})
     return minimum(input) + halfw
 end
 
-#Return a new "scaled" interval centered on the center of the input and with width equal to frac * width(input) 
+#Return a new "scaled" interval centered on the center of the input and with width equal to frac * width(input)
 function scale(input::ClosedInterval{Int}, frac::Float64)
     halfw = div(width(input),2)
     ctr = center(input)
@@ -180,10 +180,10 @@ function gen_bidirectional_stack(pmin::TL, pmax::TL, z_spacing::TL,
     end
     flash = true
     if flash_frac >= 1.0
-        @warn "las_frac was set greater than 1.0, so keeping laser on throughout the stack"
+        @warn "flash_frac was set greater than 1.0, so keeping laser on throughout the stack"
         flash = false
     elseif flash_frac <= 0
-        error("las_frac must be positive")
+        error("flash_frac must be positive")
     end
 
     pmin = uconvert(Unitful.μm, pmin)
@@ -219,7 +219,7 @@ function gen_bidirectional_stack(pmin::TL, pmax::TL, z_spacing::TL,
     #The extra -1 is needed since the forward direction does not sample the last point (the first index in the reverse direction)
     exp_intervals_back = map(x-> ClosedInterval(length(posfwd)-(maximum(x)+offset_nsamps-2), length(posfwd)-(maximum(x)-flash_nsamps-1)), exp_intervals_fwd)
 #    exp_intervals_back = spaced_intervals(posback, z_spacing, exp_time, sample_rate; delay=0.0*Unitful.s, z_pad = z_pad, alignment=:stop, rig=rig)
-    
+
     if flash
         las_intervals_fwd = map(x-> ClosedInterval(maximum(x)-flash_nsamps+1, maximum(x)), exp_intervals_fwd)
         lasfwd = gen_pulses(nsamps_stack, las_intervals_fwd)
@@ -346,7 +346,7 @@ function gen_unidirectional_stack(pmin::TL, pmax::TL, z_spacing::TL, stack_time:
     posfwd, posreset = gen_sawtooth(pmin, pmax, stack_time, reset_time, sample_rate)
 
     exp_intervals = spaced_intervals(posfwd, z_spacing, exp_time, sample_rate; z_pad = z_pad, alignment=:start, rig=rig)
-    
+
     if flash
         pulse_nsamps = calc_num_samps(flash_frac * exp_time, sample_rate)
         las_intervals = map(x-> ClosedInterval(maximum(x)-pulse_nsamps+1, maximum(x)), exp_intervals)
@@ -384,4 +384,4 @@ function gen_2d_timeseries(position::TL, nframes::Int, exp_time::TT, inter_exp_t
     output = Dict("positioner" => pos, "camera" => cam, "laser" => las)
     return output
 end
- 
+

--- a/src/write.jl
+++ b/src/write.jl
@@ -150,7 +150,7 @@ end
 
 function write_commands(fname::String, coms::Vector{ImagineSignal}, nstacks::NS,
                         nframes_per_stack::NF, exp_time::EXP;
-                        exp_trig_mode = ["External Start";], isbidi=false,
+                        exp_trig_mode = ["External Start";], isbidi=false, vertical_lines=nothing,
                         skip_validation=false) where{NS<:Union{Int, Vector{Int}}, NF<:Union{Int, Vector{Int}}, EXP<:Union{HasTimeUnits, Vector{HasTimeUnits}}}
     @assert splitext(fname)[2] == ".json"
     if isa(exp_trig_mode, AbstractString)
@@ -161,7 +161,7 @@ function write_commands(fname::String, coms::Vector{ImagineSignal}, nstacks::NS,
     if !skip_validation
         print("Validating signals before writing...\n")
         check_cam_meta(coms_used, nstacks, nframes_per_stack, exp_time, exp_trig_mode)
-        validate_all(coms_used; check_is_sufficient = true)
+        validate_all(coms_used; check_is_sufficient = true, vertical_lines=vertical_lines)
         print("...finished validating signals\n")
     end
     which_cams = map(name, getcameras(coms))


### PR DESCRIPTION
This fixes a bug reported via email by @jona125. The key change is allowing the user to pass `vertical_lines` to `write_commands` to communicate the anticipated frame size. I am not sure whether there's any way of using the same value to control the acquisition.

I'm happy to accept feedback on any of this, including the naming of the parameter `vertical_lines`.