### PR TITLE
change sample mapping method from raw value to other units

### DIFF
--- a/rigs/dummy6002.jl
+++ b/rigs/dummy6002.jl
@@ -53,7 +53,7 @@ LASER_OFF_TIME[rig_key] = 100 * Unitful.μs
 CAMERA_ON_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 CAMERA_OFF_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 
-PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+PIEZO_RANGES[rig_key] = (0..32767, 0.0μm .. 400.0μm, 0.0V .. 10.0V)
 PIEZO_MAX_SPEED[rig_key] = 2000*Unitful.μm / Unitful.s
-AO_RANGE[rig_key] = -10.0V .. 10.0V
+AO_RANGE[rig_key] = (-32768..32767, -10.0V .. 10.0V)
 AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/rigs/ocpi1.jl
+++ b/rigs/ocpi1.jl
@@ -69,8 +69,8 @@ LASER_OFF_TIME[rig_key] = 100 * Unitful.ms
 CAMERA_ON_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 CAMERA_OFF_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 
-PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+PIEZO_RANGES[rig_key] = (0..32767, 0.0μm .. 400.0μm, 0.0V .. 10.0V)
 PIEZO_MAX_SPEED[rig_key] = 2000*Unitful.μm / Unitful.s
-AO_RANGE[rig_key] = -10.0V .. 10.0V
+AO_RANGE[rig_key] = (-32768..32767, -10.0V .. 10.0V)
 AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)
 

--- a/rigs/ocpi2.jl
+++ b/rigs/ocpi2.jl
@@ -114,7 +114,7 @@ LASER_OFF_TIME[rig_key] = 9 * Unitful.μs
 CAMERA_ON_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 CAMERA_OFF_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 
-PIEZO_RANGES[rig_key] = (0.0μm .. 800.0μm, 0.0V .. 10.0V)
+PIEZO_RANGES[rig_key] = (0..32767, 0.0μm .. 800.0μm, 0.0V .. 10.0V)
 PIEZO_MAX_SPEED[rig_key] = 2000*Unitful.μm / Unitful.s
-AO_RANGE[rig_key] = -10.0V .. 10.0V
+AO_RANGE[rig_key] = (-32768..32767, -10.0V .. 10.0V)
 AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/rigs/ocpi_lsk.jl
+++ b/rigs/ocpi_lsk.jl
@@ -115,7 +115,7 @@ LASER_OFF_TIME[rig_key] = 100 * Unitful.μs
 CAMERA_ON_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 CAMERA_OFF_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 
-PIEZO_RANGES[rig_key] = (0.0μm .. 400.0μm, 0.0V .. 10.0V)
+PIEZO_RANGES[rig_key] = (0..32767, 0.0μm .. 400.0μm, 0.0V .. 10.0V)
 PIEZO_MAX_SPEED[rig_key] = 2000*Unitful.μm / Unitful.s
-AO_RANGE[rig_key] = -10.0V .. 10.0V
+AO_RANGE[rig_key] = (-32768..32767, -10.0V .. 10.0V)
 AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)

--- a/rigs/realm.jl
+++ b/rigs/realm.jl
@@ -2,10 +2,10 @@ rig_key = "realm"
 push!(RIGS, rig_key)
 #Mappings from DAQ channel to friendlier default names
 const realm_mappings = Dict("AO0"=>"axial piezo",
-                      "AO1"=>"analogout1",
+                      "AO1"=>"horizontal piezo",
                       "AI0"=>"axial piezo monitor",
-                      "AI1"=>"stimuli",
-                      "AI2"=>"analogin1",
+                      "AI1"=>"horizontal piezo monitor",
+                      "AI2"=>"stimuli",
                       "AI3"=>"analogin2",
                       "AI4"=>"AI4",
                       "AI5"=>"AI5",
@@ -35,8 +35,8 @@ const realm_aochans = map(x->"AO$(x)", 0:1)
 const realm_aichans = map(x->"AI$(x)", 0:15)
 const realm_dochans = map(x->"P0.$(x)", 0:6)
 const realm_dichans = ["P0.7";]
-const realm_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo"])
-const realm_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor"])
+const realm_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo","horizontal piezo"])
+const realm_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor","horizontal piezo monitor"])
 const realm_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"])
 const realm_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"])
 const realm_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["488nm laser shutter"])

--- a/rigs/realm.jl
+++ b/rigs/realm.jl
@@ -35,13 +35,13 @@ const realm_aochans = map(x->"AO$(x)", 0:1)
 const realm_aichans = map(x->"AI$(x)", 0:15)
 const realm_dochans = map(x->"P0.$(x)", 0:6)
 const realm_dichans = ["P0.7";]
-const realm_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo","horizontal piezo"])
-const realm_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor","horizontal piezo monitor"])
+const realm_pos_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo", "horizontal piezo"])
+const realm_pos_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["axial piezo monitor", "horizontal piezo monitor"])
 const realm_cam_ctrl_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1"])
 const realm_cam_mon_chans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["camera1 frame monitor"])
 const realm_laschans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["488nm laser shutter"])
 const realm_stimchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], ["stimulus$x" for x = 1:5])
-const realm_fixed_names = ["axial piezo", "axial piezo monitor", "488nm laser shutter", "camera1", "camera1 frame monitor", "stimuli"]
+const realm_fixed_names = ["axial piezo", "axial piezo monitor", "horizontal piezo", "horizontal piezo monitor", "488nm laser shutter", "camera1", "camera1 frame monitor", "stimuli"]
 const realm_fixed_daqchans = map(x->DEFAULT_NAMES_TO_DAQCHANS[rig_key][x], realm_fixed_names)
 
 AO_CHANS[rig_key] = OrderedSet(realm_aochans)
@@ -69,8 +69,8 @@ LASER_OFF_TIME[rig_key] = 10 * Unitful.ms
 CAMERA_ON_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 CAMERA_OFF_TIME[rig_key] = 19526.0 * Unitful.ns #This is the worst jitter measured with Edge 5.5 and 4.2 cameras, see ImagineInterface issue #18
 
-PIEZO_RANGES[rig_key] = (-400.0μm .. 400.0μm, -10.0V .. 10.0V)
+PIEZO_RANGES[rig_key] = (-32768..32767, -400.0μm .. 400.0μm, -10.0V .. 10.0V)
 PIEZO_MAX_SPEED[rig_key] = 2000*Unitful.μm / Unitful.s
-AO_RANGE[rig_key] = -10.0V .. 10.0V
+AO_RANGE[rig_key] = (-32768..32767, -10.0V .. 10.0V)
 AI_RANGE[rig_key] = AO_RANGE[rig_key] #TODO: make sure this is true.  (true if we are recording -10..10V on analog inputs)
 


### PR DESCRIPTION
- Previous
     For the piezo, raw value interval is fixed as `0..typemax(Int16)` and this is mapped to user specified `PIEZO_RANGES` value
     according to the `rig_key` as below
     `PIEZO_RANGES[rig_key] = (0.0μm .. 800.0μm, 0.0V .. 10.0V)`
     But, in this case, there is no way to map `typemin(Int16)..typemax(int16)` to `(-400.0μm .. 400.0μm, -10.0V .. 10.0V)` which
     is required for 'realm' microscope.
- Now
     We can specify the raw value also as
     `PIEZO_RANGES[rig_key] = (-32768..32767, -400.0μm .. 400.0μm, -10.0V .. 10.0V)`
     * note : raw range `typemin(Int16)..typemax(int16)` doesn't work. During the waveform validity check, it need to call 
                 `width(typemin(Int16)..typemax(int16))`. But, it return `0` different from expected value `65536`. But, the direct 
                 value `-32768..32767` works because the eltype of this range is not the `Int16` but `Int64` in this case.